### PR TITLE
add luaJIT_compat52 symbol

### DIFF
--- a/doc/ext_c_api.html
+++ b/doc/ext_c_api.html
@@ -174,6 +174,11 @@ Note that you can only define <b>a single global wrapper function</b>,
 so be careful when using this mechanism from multiple C++ modules.
 Also note that this mechanism is not without overhead.
 </p>
+<h2 id="luaJIT_compat52"><tt>int luaJIT_compat52</tt></h2>
+<p>
+This symbol allows to know how luajit was built,
+ie. with or without <tt>-DLUAJIT_ENABLE_LUA52COMPAT</tt>.
+</p>
 <br class="flush">
 </div>
 <div id="foot">

--- a/src/lj_api.c
+++ b/src/lj_api.c
@@ -28,6 +28,8 @@
 #include "lj_strscan.h"
 #include "lj_strfmt.h"
 
+int luaJIT_compat52 = LJ_52;
+
 /* -- Common helper functions --------------------------------------------- */
 
 #define api_checknelems(L, n)		api_check(L, (n) <= (L->top - L->base))

--- a/src/luajit.h
+++ b/src/luajit.h
@@ -76,4 +76,6 @@ LUA_API const char *luaJIT_profile_dumpstack(lua_State *L, const char *fmt,
 /* Enforce (dynamic) linker error for version mismatches. Call from main. */
 LUA_API void LUAJIT_VERSION_SYM(void);
 
+LUA_API int luaJIT_compat52;
+
 #endif


### PR DESCRIPTION
in a C module/extension, this symbol allows to know how luajit was compiled.

initially submitted as https://github.com/LuaJIT/LuaJIT/pull/404