### PR TITLE
Fix math functions floor and ceil for s390x

### DIFF
--- a/dynasm/dasm_s390x.lua
+++ b/dynasm/dasm_s390x.lua
@@ -825,6 +825,7 @@ map_op = {
   esxtr_2 =	"0000b3ef0000RRE",
   ex_2 =	"000044000000RX-a",
   exrl_2 =	"c60000000000RIL-b",
+  fidbra_4 =	"0000b35f0000RRF-e",
   fidr_2 =	"0000b37f0000RRE",
   fier_2 =	"0000b3770000RRE",
   fixr_2 =	"0000b3670000RRE",

--- a/src/vm_s390x.dasc
+++ b/src/vm_s390x.dasc
@@ -1577,7 +1577,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  jh ->fff_fallback
   |  brasl r14, ->vm_ .. func
   |  cfdbr RB, 0, f0
-  |  jo ->fff_resf0
+  |  jnlh ->fff_resf0                   // branch on cc0 or cc3
   |  llgfr RB, RB
   |  j ->fff_resi
   |.endmacro
@@ -2106,14 +2106,8 @@ static void build_subroutines(BuildCtx *ctx)
   |// Value to round is in f0. May clobber f0-f7 and r0. Return address is r14.
   |.macro vm_round, name, mask
   |->name:
-  |  lghi r0, 1
-  |  cdfbr f1, r0
-  |  didbr f0, f2, f1, mask // f0=remainder, f2=quotient.
-  |  jnle >1
-  |  ldr f0, f2
+  |  fidbra f0, mask, f0, 0
   |  br r14
-  |1: // partial remainder (sanity check)
-  |  stg r0, 0
   |.endmacro
   |
   |  vm_round vm_floor, 7 // Round towards -inf.


### PR DESCRIPTION
Prior this patch floor and ceil computed for certain inputs wrong
values.  For example `floor(1/0)` returned `nan` whereas `+inf` is
expected.

Fixes #8 