### PR TITLE
Add Window CI using Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,8 +26,10 @@ jobs:
     maxParallel: 3
     matrix:
       Linux_x64:
-        buildFlags:
+        buildFlags: -DLUA_USE_ASSERT
       Linux_x64_GC64:
-        buildFlags: -DLUAJIT_ENABLE_GC64
+        buildFlags: -DLUA_USE_ASSERT -DLUAJIT_ENABLE_GC64
+      Linux_x64_NoJIT:
+        buildFlags: -DLUA_USE_ASSERT -DLUAJIT_DISABLE_JIT
   steps:
   - template: ./linux.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,3 +18,16 @@ jobs:
         buildMode: gc64
   steps:
   - template: ./windows.yml
+
+- job: Linux
+  pool:
+    vmImage: 'ubuntu-18.04'
+  strategy:
+    maxParallel: 3
+    matrix:
+      Linux_x64:
+        buildFlags:
+      Linux_x64_GC64:
+        buildFlags: -DLUAJIT_ENABLE_GC64
+  steps:
+  - template: ./linux.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,20 @@
+# LuaJIT Azure Piplines build script
+jobs:
+- job: Windows_Build
+  pool:
+    vmImage: windows-2019
+
+  strategy:
+    maxParallel: 3
+    matrix:
+      Win_x86:
+        VC_ARCH: x86
+        buildMode:
+      Win_x64:
+        VC_ARCH: amd64
+        buildMode:
+      Win_x64_GC64:
+        VC_ARCH: amd64
+        buildMode: gc64
+  steps:
+  - template: ./windows.yml

--- a/linux.yml
+++ b/linux.yml
@@ -3,3 +3,8 @@ steps:
      cd src
      make -j  XCFLAGS="$(buildFlags)"
     displayName: Linux Build
+
+  - script: |
+     cd test
+     ../src/luajit test.lua
+    displayName: Linux Tests

--- a/linux.yml
+++ b/linux.yml
@@ -5,6 +5,6 @@ steps:
     displayName: Linux Build
 
   - script: |
-     cd test
-     ../src/luajit test.lua
+     cd src
+     make test
     displayName: Linux Tests

--- a/linux.yml
+++ b/linux.yml
@@ -1,0 +1,5 @@
+steps:
+  - script: |
+     cd src
+     make -j  XCFLAGS="$(buildFlags)"
+    displayName: Linux Build

--- a/windows.yml
+++ b/windows.yml
@@ -1,0 +1,9 @@
+steps:
+  - script: |
+     for /f "usebackq tokens=*" %%i in (`"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+     set InstallDir=%%i
+     )
+     call "%InstallDir%\Common7\Tools\vsdevcmd.bat" -arch=$(VC_ARCH) -startdir=none
+     cd src
+     call msvcbuild.bat $(buildMode)
+    displayName: Windows Build - $(VC_ARCH).

--- a/windows.yml
+++ b/windows.yml
@@ -7,3 +7,8 @@ steps:
      cd src
      call msvcbuild.bat $(buildMode)
     displayName: Windows Build - $(VC_ARCH).
+
+  - script: |
+     cd test
+     ..\src\luajit.exe test.lua
+    displayName: Windows Tests - $(VC_ARCH).


### PR DESCRIPTION
Add a CI for windows using [Azure pipelines](https://azure.microsoft.com/en-gb/services/devops/pipelines/) which is free for open source projects and has GitHub integration. I have it setup using my own account here [here](https://tfransham.visualstudio.com/LuaJIT/_build?definitionId=1&_a=summary) but it would be better to make your own account to run it off.
The azure-pipelines.yml file has a build matrix setup to compile on windows for both 32 bit, 64 bit and GC 64 mode using MSVC 2019 compiler. The msvcbuild.bat is very limited in what build options you can pass it on the command line so windows is not compiled with asserts unlike Linux