### PR TITLE
fold: Fix up conversion mode in simplify_conv_narrow

### DIFF
--- a/src/lj_opt_fold.c
+++ b/src/lj_opt_fold.c
@@ -1260,6 +1260,7 @@ LJFOLDF(simplify_conv_narrow)
   IROp op = (IROp)fleft->o;
   IRType t = irt_type(fins->t);
   IRRef op1 = fleft->op1, op2 = fleft->op2, mode = fins->op2;
+  mode = (IRT_INT << IRCONV_DSH) | (mode & IRCONV_SRCMASK);
   PHIBARRIER(fleft);
   op1 = emitir(IRTI(IR_CONV), op1, mode);
   op2 = emitir(IRTI(IR_CONV), op2, mode);

--- a/test/lib/ffi/ffi_convert.lua
+++ b/test/lib/ffi/ffi_convert.lua
@@ -7,6 +7,7 @@ dofile("../common/ffi_util.inc")
 local tonumber = tonumber
 
 ffi.cdef[[
+typedef unsigned int u32;
 typedef struct bar_t {
   int v, w;
 } bar_t;
@@ -767,6 +768,18 @@ do
 
   -- assignment to function pointer
   x.ppf = ffi.C.strcpy
+end
+
+do
+local i = 1
+local sq = ffi.cast("u32", 42)
+
+for case = 1, 10 do
+    while i > 0 do
+        sq = ffi.cast("u32", sq * sq)
+	i = i / 2
+    end
+end
 end
 
 do


### PR DESCRIPTION
Fixes #37.

simplify_conv_narrow transforms a 64-bit to 32-bit int conversion
after an operation (e.g. add, sub, mul) to an op of the converted
operands by simply converting the operands into 32-bit int.  It
however fails to update the destination type of the conversion mode
because of which one ends up with inconsistent IR and fails with an
assertion.

The test case is incorporated into this patch but it doesn't actually
get executed in the make check.  ffi_convert.lua needs extensive
fixing up to enable it in the testsuite and is currently out of scope
for 2.1.2.

Signed-off-by: Siddhesh Poyarekar <siddhesh@gotplt.org>
Signed-off-by: spacewander <spacewanderlzx@gmail.com>