### PR TITLE
Document release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,24 @@ The project repository on github has the following main branches:
   branch aims to remain compatible with the LuaJIT v2.1 branch.
 * **v2.0**: This remains a bug fix branch that tracks the v2.0 branch of
   upstream LuaJIT.  This branch currently does not have a maintainer.
+
+### Release Process
+
+The following steps need to be performed before tagging a moonjit release:
+
+* Update `RELVER` to the new version number and set `PREREL` to an empty string
+  in [Makefile](Makefile)
+* Update [etc/luajit.pc](etc/luajit.pc) with the new version
+* update `LUA_LJDIR` in [src/luaconf.h](src/luaconf.h)
+* Update `LUAJIT_VERSION`, `LUAJIT_VERSION_NUM` and `LUAJIT_VERSION_SYM` in
+  [src/luajit.h](src/luajit.h)
+* Update version check assertions in scripts in [src/jit](src/jit).  The are of
+  the form:
+  `assert(jit.version_num == xxxxxx, "LuaJIT core/library version mismatch")`
+  where `xxxxxx` is the value of `LUAJIT_VERSION_NUM`.
+* Draft release notes based on changes between `HEAD` and the last tag.
+* Tag release and put in release notes on GitHub.
+* Update `PREREL` in [Makefile(Makefile) to `-dev` to indicate that development
+  is now open.
+* Announce.
+* Hack on next release.


### PR DESCRIPTION
moonjit v2.1.1 release was a minor disaster with multiple issues.  One
of the problems was that it was unclear which all files had to be
updated to make the release and therefore a few files in `src/jit`
slipped through without an update.

Document the release process and also all the files that need to be
updated so that there is a ready checklist to follow while making a
release.  Eventually this should just become a script or a make
target.

(This is going on v2.1 first and then on master).

Signed-off-by: Siddhesh Poyarekar <siddhesh@gotplt.org>