### PR TITLE
test: Check for package.searchers only in compat5.2

### DIFF
--- a/test/lib/contents.lua
+++ b/test/lib/contents.lua
@@ -121,8 +121,11 @@ end
 
 do --- pre-5.2 package +lua<5.2
   assert(package.loaders)
-  assert(not package.searchers)
   assert(package.seeall)
+end
+
+do --- 5.2 compat package +compat5.2
+  assert(package.searchers)
 end
 
 do --- 5.2 package +lua>=5.2


### PR DESCRIPTION
LuaJIT version check for lua will return true for +lua<5.2 since it
does not fully implement 5.2.  Move the (not package.searchers) check
to +compat5.2 instead of the version check since it is implemented by
compat5.2.