### PR TITLE
fold: keep type of emitted CONV in sync with its mode

### DIFF
--- a/src/lj_opt_fold.c
+++ b/src/lj_opt_fold.c
@@ -1260,10 +1260,9 @@ LJFOLDF(simplify_conv_narrow)
   IROp op = (IROp)fleft->o;
   IRType t = irt_type(fins->t);
   IRRef op1 = fleft->op1, op2 = fleft->op2, mode = fins->op2;
-  mode = (IRT_INT << IRCONV_DSH) | (mode & IRCONV_SRCMASK);
   PHIBARRIER(fleft);
-  op1 = emitir(IRTI(IR_CONV), op1, mode);
-  op2 = emitir(IRTI(IR_CONV), op2, mode);
+  op1 = emitir(IRT(IR_CONV, t), op1, mode);
+  op2 = emitir(IRT(IR_CONV, t), op2, mode);
   fins->ot = IRT(op, t);
   fins->op1 = op1;
   fins->op2 = op2;


### PR DESCRIPTION
Alternative fix for #37

When emitting CONV make sure that its type matches its destination IRType.

This keeps IR fully internally consistent with respect to types - i.e. if
we push narrowing CONV Dt.St upwards through an arithmetic operation of type
St we end up with arithmetic operation of type Dt and two convertions
CONV Dt.St which narrow the operands.

Previous variantion of the fix introduced slight inconsistency with types
(inserted convertions were CONV int.St while arithmetic operation was still of
type Dt).