### PR TITLE
Renamed LuaJIT to MoonJIT

### DIFF
--- a/src/luajit.h
+++ b/src/luajit.h
@@ -30,11 +30,11 @@
 
 #include "lua.h"
 
-#define LUAJIT_VERSION		"LuaJIT 2.1.0-beta3"
+#define LUAJIT_VERSION		"MoonJIT v2.1.2"
 #define LUAJIT_VERSION_NUM	20100  /* Version 2.1.0 = 02.01.00. */
 #define LUAJIT_VERSION_SYM	luaJIT_version_2_1_0_beta3
-#define LUAJIT_COPYRIGHT	"Copyright (C) 2005-2017 Mike Pall"
-#define LUAJIT_URL		"http://luajit.org/"
+#define LUAJIT_COPYRIGHT	"Copyright (C) 2005-2019 MoonJIT contributors"
+#define LUAJIT_URL		"https://github.com/moonjit/moonjit"
 
 /* Modes for luaJIT_setmode. */
 #define LUAJIT_MODE_MASK	0x00ff


### PR DESCRIPTION
It makes no sense to have LuaJIT v2.1-beta3 when we use MoonJIT v2.1.2.