### PR TITLE
build changes for clang compiler on ppc64le arch

### DIFF
--- a/src/host/buildvm_asm.c
+++ b/src/host/buildvm_asm.c
@@ -387,7 +387,7 @@ void emit_asm(BuildCtx *ctx)
 #if !(LJ_TARGET_PS3 || LJ_TARGET_PSVITA)
     fprintf(ctx->fp, "\t.section .note.GNU-stack,\"\"," ELFASM_PX "progbits\n");
 #endif
-#if LJ_TARGET_PPC && !LJ_TARGET_PS3 && !LJ_ABI_SOFTFP
+#if LJ_TARGET_PPC && !LJ_TARGET_PS3 && !LJ_ABI_SOFTFP && !__clang__
     /* Hard-float ABI. */
     fprintf(ctx->fp, "\t.gnu_attribute 4, 1\n");
 #endif

--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -445,6 +445,16 @@
 #error "Need at least GCC 4.8 or newer"
 #endif
 #endif
+#elif LUAJIT_ARCH_PPC
+#if __clang__
+#if ((__clang_major__ < 3) || ((__clang_major__ == 3) && __clang_minor__ < 5)) && !defined(__NX_TOOLCHAIN_MAJOR__)
+#error "Need at least Clang 3.5 or newer"
+#endif
+#else
+#if (__GNUC__ < 4) || ((__GNUC__ == 4) && __GNUC_MINOR__ < 8)
+#error "Need at least GCC 4.8 or newer"
+#endif
+#endif
 #elif !LJ_TARGET_PS3
 #if (__GNUC__ < 4) || ((__GNUC__ == 4) && __GNUC_MINOR__ < 3)
 #error "Need at least GCC 4.3 or newer"


### PR DESCRIPTION
Raising the pull request needed for ppc64le clang compiler build (checked with clang version 8.0.1). 

Changes include 1) bypassing the 'gnu_attribute' for clang build which seems gcc specific and 
                            2) Correctly check the clang compiler version.