### PR TITLE
FFI callback docs: "self-calling" :free() is safe

### DIFF
--- a/doc/ext_ffi_api.html
+++ b/doc/ext_ffi_api.html
@@ -490,7 +490,8 @@ have some extra methods:
 Free the resources associated with a callback. The associated Lua
 function is unanchored and may be garbage collected. The callback
 function pointer is no longer valid and must not be called anymore
-(it may be reused by a subsequently created callback).
+(it may be reused by a subsequently created callback). It is safe
+to call <tt>cb:free()</tt> when that callback is currently executing.
 </p>
 
 <h3 id="callback_set"><tt>cb:set(func)</tt></h3>


### PR DESCRIPTION
https://www.freelists.org/post/luajit/Safely-free-FFI-callback-while-inside-of-it,1

I'm failing to catch attention [in original repo](https://github.com/LuaJIT/LuaJIT/pull/490) so let me try here.  This should be mergable to all versions/branches (2.0 is common denominator).