### PR TITLE
Add support for Optimized Hash under MSVC

### DIFF
--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -191,7 +191,7 @@
 #ifdef LUAJIT_ENABLE_GC64
 #define LJ_TARGET_GC64		1
 #endif
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(_MSC_VER)
 #define LJ_HAS_OPTIMISED_HASH	1
 #endif
 

--- a/src/lj_str.c
+++ b/src/lj_str.c
@@ -125,7 +125,7 @@ lj_str_hashfn lj_str_hash = lj_str_hash_default;
 #endif
 
 MSize
-lj_str_hash_default(const char *str, size_t lenx)
+lj_str_hash_default(const char *str, MSize lenx)
 {
   MSize len = (MSize)lenx;
   MSize a, b, h = len;
@@ -169,7 +169,7 @@ GCstr *lj_str_new(lua_State *L, const char *str, size_t lenx)
     return &g->strempty;
   }
 
-  h = lj_str_hash(str, lenx);
+  h = lj_str_hash(str, len);
 
   /* Check if the string has already been interned. */
   o = gcref(g->strhash[h & g->strmask]);

--- a/src/lj_str.h
+++ b/src/lj_str.h
@@ -24,11 +24,11 @@ LJ_FUNC void LJ_FASTCALL lj_str_free(global_State *g, GCstr *s);
 #define lj_str_newz(L, s)	(lj_str_new(L, s, strlen(s)))
 #define lj_str_newlit(L, s)	(lj_str_new(L, "" s, sizeof(s)-1))
 
-typedef MSize (*lj_str_hashfn) (const char *, size_t);
+typedef MSize (*lj_str_hashfn) (const char *, MSize);
 
 extern lj_str_hashfn lj_str_hash;
 
-extern MSize lj_str_hash_default(const char *str, size_t lenx);
+extern MSize lj_str_hash_default(const char *str, MSize lenx);
 
 extern void lj_str_hash_init(uint32_t flags);
 

--- a/src/lj_str_hash.c
+++ b/src/lj_str_hash.c
@@ -11,7 +11,7 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <time.h>
-#include <smmintrin.h>
+#include <nmmintrin.h>
 
 #if defined(_MSC_VER)
 #include <process.h>
@@ -129,7 +129,7 @@ static uint32_t lj_str_hash_16_128(const char* str, MSize len)
   h1 = lj_crc32_u64(h1, *cast_uint64p(str + len - 16));
   h2 = lj_crc32_u64(h2, *cast_uint64p(str + len - 8));
 
-  return lj_crc32_u32(h1, h2);
+  return lj_crc32_u32((uint32_t)h1, (uint32_t)h2);
 }
 
 /* **************************************************************************
@@ -184,7 +184,7 @@ static void str_hash_init_random(void)
 
   /* Init seed */
   seed = lj_crc32_u32(0, getpid());
-  seed = lj_crc32_u32(seed, time(NULL));
+  seed = lj_crc32_u32(seed, (uint32_t)time(NULL));
   srandom(seed);
 
   /* Now start to populate the random_pos[][]. */
@@ -264,7 +264,7 @@ static LJ_NOINLINE uint32_t lj_str_hash_128_above(const char* str,
   h1 = lj_crc32_u64(h1, *cast_uint64p(str));
   h2 = lj_crc32_u64(h2, *cast_uint64p(str + len - 8));
 
-  h1 = lj_crc32_u32(h1, h2);
+  h1 = lj_crc32_u32((uint32_t)h1, (uint32_t)h2);
   return (uint32_t)h1;
 }
 

--- a/src/lj_str_hash.c
+++ b/src/lj_str_hash.c
@@ -65,7 +65,7 @@ static const uint32_t* cast_uint32p(const char* str)
 }
 
 /* hash string with len in [1, 4) */
-static LJ_AINLINE uint32_t lj_str_hash_1_4(const char* str, uint32_t len)
+static LJ_AINLINE uint32_t lj_str_hash_1_4(const char* str, MSize len)
 {
 #if 0
   /* TODO: The if-1 part (i.e the original algorithm) is working better when
@@ -94,7 +94,7 @@ static LJ_AINLINE uint32_t lj_str_hash_1_4(const char* str, uint32_t len)
 }
 
 /* hash string with len in [4, 16) */
-static LJ_AINLINE uint32_t lj_str_hash_4_16(const char* str, uint32_t len)
+static LJ_AINLINE uint32_t lj_str_hash_4_16(const char* str, MSize len)
 {
   uint64_t v1, v2, h;
 
@@ -109,11 +109,11 @@ static LJ_AINLINE uint32_t lj_str_hash_4_16(const char* str, uint32_t len)
   h = lj_crc32_u32(0, len);
   h = lj_crc32_u64(h, v1);
   h = lj_crc32_u64(h, v2);
-  return h;
+  return (uint32_t)h;
 }
 
 /* hash string with length in [16, 128) */
-static uint32_t lj_str_hash_16_128(const char* str, uint32_t len)
+static uint32_t lj_str_hash_16_128(const char* str, MSize len)
 {
   uint64_t h1, h2;
   uint32_t i;
@@ -226,7 +226,7 @@ static LJ_AINLINE uint32_t get_random_pos_unsafe(uint32_t chunk_sz_order,
 }
 
 static LJ_NOINLINE uint32_t lj_str_hash_128_above(const char* str,
-    uint32_t len)
+    MSize len)
 {
   uint32_t chunk_num, chunk_sz, chunk_sz_log2, i, pos1, pos2;
   uint64_t h1, h2, v;
@@ -265,11 +265,11 @@ static LJ_NOINLINE uint32_t lj_str_hash_128_above(const char* str,
   h2 = lj_crc32_u64(h2, *cast_uint64p(str + len - 8));
 
   h1 = lj_crc32_u32(h1, h2);
-  return h1;
+  return (uint32_t)h1;
 }
 
 /* NOTE: the "len" should not be zero */
-static LJ_AINLINE uint32_t lj_str_hash_opt(const char* str, size_t len)
+static LJ_AINLINE uint32_t lj_str_hash_opt(const char* str, MSize len)
 {
   if (len < 128) {
     if (len >= 16) { /* [16, 128) */

--- a/src/lj_str_hash.c
+++ b/src/lj_str_hash.c
@@ -25,9 +25,6 @@
 #include "lj_str.h"
 #include "lj_jit.h"
 
-#if LUAJIT_TARGET == LUAJIT_ARCH_X86
-#error "Optimized hash not supported for x86 builds"
-#endif
 
 #if defined(_MSC_VER)
 /*


### PR DESCRIPTION
Add support for Optimized Hash under Visual c++ on x64 for both cl and clang-cl. I also changed lj_str_hashfn size parameter to MSize since string can't be larger than that and its just be implicitly truncated in lj_str_hash.c which was causing lots of warnings.