### PR TITLE
Drop valgrind rules for str_fastcmp

### DIFF
--- a/src/lj.supp
+++ b/src/lj.supp
@@ -24,18 +24,3 @@
    Memcheck:Cond
    fun:lj_str_new
 }
-{
-   Optimized string compare
-   Memcheck:Addr4
-   fun:str_fastcmp
-}
-{
-   Optimized string compare
-   Memcheck:Addr1
-   fun:str_fastcmp
-}
-{
-   Optimized string compare
-   Memcheck:Cond
-   fun:str_fastcmp
-}


### PR DESCRIPTION
Fixes #108

Advantages:
+ we do not need to consider page size or endianess
+ code is easier to read
+ no false positives in valgrind
+ allows to compare 0-sized strings

Disadvantages:
- 1-3 byte accesses instead of 1 dword access at end of string

benchmarks wanted
