### PR TITLE
Added nmake script for building ctest.dll and cpptest.dll

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -9,8 +9,8 @@ ifeq ($(OS),Windows_NT)
 	CTEST = clib/ctest.dll
 	CPPTEST = clib/cpptest.dll
 else
-	CTEST = clib/ctest
-	CPPTEST = clib/cpptest
+	CTEST = clib/ctest.so
+	CPPTEST = clib/cpptest.so
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Linux)
 		HOST = Linux
@@ -35,5 +35,5 @@ cpptest:
 
 .PHONY: clean
 clean:
-	-${RM} clib/cpptest clib/ctest src/cpptest.o src/ctest.o
+	-${RM} clib/cpptest.so clib/ctest.so src/cpptest.o src/ctest.o
 

--- a/test/Makefile.win
+++ b/test/Makefile.win
@@ -1,0 +1,23 @@
+INTDIR=.\clib
+
+CC=$(CC) /nologo
+LINK=link /nologo /dll /NOIMPLIB ../src/lua51.lib
+CCCOMMON=/c /Fo"$(INTDIR)\\" /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE /DLUA_BUILD_AS_DLL /MD /EHsc /I"..\src"
+CFLAGS=$(CFLAGS) /TC $(CCCOMMON)
+
+all: clib/cpptest.dll clib/ctest.dll
+
+{.\src}.c.obj:
+  $(CC) $(CFLAGS) $<
+
+{.\src}.cpp.obj:
+  $(CC) $(CCCOMMON) $<
+  
+clib/ctest.dll: clib/ctest.obj
+  $(LINK) -out:clib/ctest.dll $**
+
+clib/cpptest.dll: clib/cpptest.obj
+  $(LINK) -out:clib/cpptest.dll $**
+
+clean:
+	del clib\*.obj clib\*.dll clib\*.lib clib\*.exp

--- a/test/lib/contents.lua
+++ b/test/lib/contents.lua
@@ -19,7 +19,12 @@ local function check(m, expected, exclude)
 end
 
 do --- base +ffi
-  check(_G, "_G:_VERSION:arg:assert:collectgarbage:coroutine:debug:dofile:error:exdata:getmetatable:io:ipairs:load:loadfile:math:next:os:package:pairs:pcall:print:rawequal:rawget:rawset:require:select:setmetatable:string:table:tonumber:tostring:type:utf8:xpcall", "rawlen:bit:bit32:jit:gcinfo:setfenv:getfenv:loadstring:unpack:module:newproxy")
+  if jit.os == "Linux" then
+    check(_G, "_G:_VERSION:arg:assert:collectgarbage:coroutine:ctest:debug:dofile:error:exdata:getmetatable:io:ipairs:load:loadfile:math:next:os:package:pairs:pcall:print:rawequal:rawget:rawset:require:select:setmetatable:string:table:tonumber:tostring:type:utf8:xpcall", "rawlen:bit:bit32:jit:gcinfo:setfenv:getfenv:loadstring:unpack:module:newproxy")
+  else
+    check(_G, "_G:_VERSION:arg:assert:collectgarbage:coroutine:debug:dofile:error:exdata:getmetatable:io:ipairs:load:loadfile:math:next:os:package:pairs:pcall:print:rawequal:rawget:rawset:require:select:setmetatable:string:table:tonumber:tostring:type:utf8:xpcall", "rawlen:bit:bit32:jit:gcinfo:setfenv:getfenv:loadstring:unpack:module:newproxy")
+  end
+
 end
 
 do --- base -ffi
@@ -149,7 +154,11 @@ do --- package.loaded +ffi
       loaded[k] = v
     end
   end
-  check(loaded, "_G:coroutine:debug:io:math:os:package:string:table:thread.exdata", "bit:bit32:common:ffi:jit:table.new")
+  if jit.os == "Linux" then
+    check(loaded, "_G:coroutine:ctest:debug:io:math:os:package:string:table:thread.exdata", "bit:bit32:common:ffi:jit:table.new")
+  else
+    check(loaded, "_G:coroutine:debug:io:math:os:package:string:table:thread.exdata", "bit:bit32:common:ffi:jit:table.new")
+  end
 end
 
 do --- package.loaded -ffi

--- a/test/lib/ffi/ffi_call.lua
+++ b/test/lib/ffi/ffi_call.lua
@@ -77,7 +77,7 @@ local C = nil
 if jit and jit.os then
 
   if jit.os == "Linux" then
-    C = ffi.load("clib/ctest")
+    C = ffi.load("clib/ctest.so")
 
   elseif jit.os == "Windows" then
     -- need to create ctest.dll and load it without using pcall.

--- a/test/lib/ffi/ffi_call.lua
+++ b/test/lib/ffi/ffi_call.lua
@@ -78,13 +78,8 @@ if jit and jit.os then
 
   if jit.os == "Linux" then
     C = ffi.load("clib/ctest.so")
-
-  elseif jit.os == "Windows" then
-    -- need to create ctest.dll and load it without using pcall.
-    local success, lib = pcall(ffi.load, "clib/ctest.dll")
-    if not success then
-      return
-    end
+  else
+    return
   end
 end
 

--- a/test/lib/ffi/ffi_enum.lua
+++ b/test/lib/ffi/ffi_enum.lua
@@ -19,13 +19,8 @@ if jit and jit.os then
 
   if jit.os == "Linux" then
     C = ffi.load("clib/ctest.so")
-
-  elseif jit.os == "Windows" then
-    -- need to create ctest.dll and load it without using pcall.
-    local success, lib = pcall(ffi.load, "clib/ctest.dll")
-    if not success then
-      return
-    end
+  else
+    return
   end
 
 end

--- a/test/lib/ffi/ffi_enum.lua
+++ b/test/lib/ffi/ffi_enum.lua
@@ -18,7 +18,7 @@ local C = nil
 if jit and jit.os then
 
   if jit.os == "Linux" then
-    C = ffi.load("clib/ctest")
+    C = ffi.load("clib/ctest.so")
 
   elseif jit.os == "Windows" then
     -- need to create ctest.dll and load it without using pcall.

--- a/test/lib/ffi/ffi_jit_call.lua
+++ b/test/lib/ffi/ffi_jit_call.lua
@@ -40,7 +40,7 @@ do --- ffi-jit-call
   local success = nil
   if jit and jit.os then
     if jit.os == "Linux" then
-      success, lib = pcall(ffi.load, "clib/ctest")
+      success, lib = pcall(ffi.load, "clib/ctest.so")
       assert(success)
     elseif jit.os == "Windows" then
         success, lib = pcall(ffi.load, "clib/ctest.dll")

--- a/test/lib/ffi/ffi_jit_conv.lua
+++ b/test/lib/ffi/ffi_jit_conv.lua
@@ -1,8 +1,19 @@
 local ffi = require("ffi")
+local ctest = nil
+local success = nil
 
-local ctest = require("ctest")
+success, ctest = pcall(require, "ctest")
+if jit and jit.os then
+    if jit.os == "Linux" then
+        assert(success)
+    elseif jit.os == "Windows" then
+        if not success then
+            return
+        end
+    end
+end
 
-do
+do --- test-int32
   local s = ffi.new("struct { int32_t x; }")
   s.x = -0x12345678
   for i=1,100 do
@@ -11,7 +22,7 @@ do
   assert(s.x == -0x12345678+100)
 end
 
-do
+do --- test-uint32
   local s = ffi.new("struct { uint32_t x; }")
   s.x = 0x81234567
   for i=1,100 do
@@ -20,7 +31,7 @@ do
   assert(s.x == 0x81234567+100)
 end
 
-do
+do --- test-int8
   local s = ffi.new("struct { int8_t x; }")
   s.x = 42
   for i=1,100 do
@@ -30,7 +41,7 @@ do
   assert(s.x == 142-256)
 end
 
-do
+do --- test-uint8
   local s = ffi.new("struct { uint8_t x; }")
   s.x = 200
   for i=1,100 do
@@ -40,7 +51,7 @@ do
   assert(s.x == 300-256)
 end
 
-do
+do --- test-int16
   local s = ffi.new("struct { int16_t x; }")
   s.x = 32700
   for i=1,100 do
@@ -50,7 +61,7 @@ do
   assert(s.x == 32800-65536)
 end
 
-do
+do --- test-uint16
   local s = ffi.new("struct { uint16_t x; }")
   s.x = 65450
   for i=1,100 do
@@ -60,7 +71,7 @@ do
   assert(s.x == 65550-65536)
 end
 
-do
+do --- test-union-int32-uint32
   local s = ffi.new("union { int32_t x; uint32_t y; }")
   s.x = 0x7fffffff - 60
   local x,y = 0,0
@@ -75,7 +86,7 @@ do
   assert(x == y - 40*2^32)
 end
 
-do
+do --- test-union-int32-uint32-dummy
   local s = ffi.new("union { int32_t x; uint32_t y; }")
   local x, z = 0, 2^31 + 42
   for i=1,100 do
@@ -85,7 +96,7 @@ do
   assert(x == 100*(-2^31 + 42))
 end
 
-do
+do --- test-int8-uint8
   local s = ffi.new("union { int8_t x; uint8_t y; }")
   s.x = 42
   local x,y = 0,0
@@ -100,7 +111,7 @@ do
   assert(x == y - (100-(127-42))*256)
 end
 
-do
+do --- test-uint32-fold-1
   local a = ffi.new("uint32_t[?]", 101)
   for i=1,100 do a[i] = 0x80000000+i end
   local x = 0
@@ -110,7 +121,7 @@ do
   assert(x == 100)
 end
 
-do
+do --- test-uint32-fold-2
   local a = ffi.new("uint32_t[?]", 101)
   for i=1,100 do a[i] = 0x80000000+i end
   local x = 0
@@ -120,7 +131,7 @@ do
   assert(x == -0x80000000+100)
 end
 
-do
+do --- test-float
   local v = ffi.new("float", 12.5)
   local x = 0
   for i=1,100 do
@@ -129,7 +140,7 @@ do
   assert(x == 100*12.5)
 end
 
-do
+do --- test-uint32-tonumber
   local v = ffi.new("uint32_t", 0x80000000)
   local x = 0
   for i=1,100 do
@@ -138,7 +149,7 @@ do
   assert(x == 100*0x80000000)
 end
 
-do
+do --- test-int64-tonumber
   local v = ffi.new("int64_t", 0x1234567800000000ll)
   local x = 0
   for i=1,100 do
@@ -147,7 +158,7 @@ do
   assert(x == 100*0x12345678*2^32)
 end
 
-do
+do --- test-uint64-tonumber
   local v = ffi.new("uint64_t", 0x89abcdef00000000ull)
   local x = 0
   for i=1,100 do
@@ -156,7 +167,7 @@ do
   assert(x == 100*0x89abcdef*2^32)
 end
 
-do
+do --- test-int64-array
   local a = ffi.new("int64_t[?]", 101)
   for i=1,100 do a[i] = -i end
   local x = 0
@@ -166,7 +177,7 @@ do
   assert(x == -5050)
 end
 
-do
+do --- test-uint64-array
   local a = ffi.new("uint64_t[?]", 101)
   for i=1,100 do a[i] = 2^63+2^32*i end
   local x = 0
@@ -176,7 +187,7 @@ do
   assert(x == 2^63*100+2^32*5050)
 end
 
-do
+do --- test-complex
   local v = ffi.new("complex", 12.5, -3.25)
   local x = 0
   for i=1,100 do
@@ -185,7 +196,7 @@ do
   assert(x == 100*12.5)
 end
 
-do
+do --- test-struct-int64
   local s = ffi.new("struct { int64_t x;}")
   for i=1,100 do
     s.x = 0x123456789abcdef0LL
@@ -193,7 +204,7 @@ do
   assert(tonumber(s.x) == tonumber(0x123456789abcdef0LL))
 end
 
-do
+do --- test-struct-uint64
   local s = ffi.new("struct { uint64_t x;}")
   for i=1,100 do
     s.x = 0x823456789abcdef0ULL
@@ -201,14 +212,14 @@ do
   assert(tonumber(s.x) == tonumber(0x823456789abcdef0ULL))
 end
 
-do
+do --- test-misc
   ffi.cdef[[
-  typedef enum { AA, BB, CC = -42 } foo_i;
-  typedef enum { DD, EE, FF = 0x80000000u } foo_u;
+  typedef enum { AA, BB, KK = -42 } foo_i;
+  typedef enum { DD, LL, FF = 0x80000000u } foo_u;
   ]]
   local s = ffi.new("struct { foo_i x; foo_u y;}")
   for i=1,100 do
-    s.x = "CC"
+    s.x = "KK"
     assert(s.x == -42)
     s.x = "BB"
     assert(s.x == 1)
@@ -218,10 +229,10 @@ do
   local st = ffi.typeof(s)
   for i=1,100 do s = st() end
   assert(s.x == 0 and s.y == 0)
-  for i=1,100 do s = st("CC", "EE") end
+  for i=1,100 do s = st("KK", "LL") end
   assert(s.x == -42 and s.y == 1)
-  local ei = ffi.new("foo_i", "CC")
-  local eu = ffi.new("foo_u", "EE")
+  local ei = ffi.new("foo_i", "KK")
+  local eu = ffi.new("foo_u", "LL")
   for i=1,100 do s = st(ei, eu) end
   assert(s.x == -42 and s.y == 1)
   local x
@@ -229,7 +240,7 @@ do
   assert(x == -42)
 end
 
-do
+do --- test-char-ptr
   local s = ffi.new("struct { const char *x; const char *y;}")
   local a, tmp = "abcd", "ab"
   for i=1,100 do
@@ -240,7 +251,7 @@ do
   assert(ffi.string(s.y) == "ab")
 end
 
-do
+do --- test-struct
   local s = ffi.new("struct { bool b[200]; int i[200]; double d[200];}")
   for i=0,199 do s.i[i] = i-100; s.d[i] = i-100 end
   for i=0,99 do s.b[i] = 0 end
@@ -253,13 +264,13 @@ do
   for i=0,199 do assert(s.b[i] == (i ~= 100)) end
 end
 
-do
+do --- test-int16-array
   local a = ffi.new("int16_t[100]", 1)
   for i=1,99 do a[i] = a[i] + a[i-1] end
   assert(a[99] == 100)
 end
 
-do
+do --- test-lightud
   local ud = ctest.lightud(12345678)
   local s = ffi.new("struct { void *p; }")
   for i=1,100 do
@@ -269,7 +280,7 @@ do
   assert(ffi.cast("uintptr_t", s.p) == 12345678)
 end
 
-do
+do --- test-misc-2
   local x = ffi.new("struct { int & x;}", ffi.new("int[1]", 42))
   local z
   for i=1,100 do z = x.x end

--- a/test/lib/ffi/index
+++ b/test/lib/ffi/index
@@ -9,6 +9,7 @@ ffi_call.lua
 ffi_const.lua
 ffi_enum.lua
 ffi_jit_call.lua +luajit>=2.1
+ffi_jit_conv.lua
 ffi_parse_basic.lua
 ffi_parse_cdef.lua
 istype.lua

--- a/test/lib/table/index
+++ b/test/lib/table/index
@@ -1,5 +1,6 @@
 concat.lua
 insert.lua
+misc.lua
 new.lua +table.new
 pack.lua +compat5.2
 remove.lua

--- a/test/lib/table/misc.lua
+++ b/test/lib/table/misc.lua
@@ -2,7 +2,7 @@
 
 -- ABC elim
 -- +opt +abc
-do
+do  --- test-table
   local s, t = {}, {}
   for i=1,100 do t[i] = 1 end
   for i=1,100 do s[i] = t end
@@ -13,7 +13,7 @@ end
 
 --- TSETM
 -- Initialize table with multiple return values
-do
+do  --- test-table-multiple-values
   local function f(a,b,c)
     return a,b,c
   end
@@ -46,7 +46,7 @@ end
 
 --- TSETM 2
 -- Initialize table with function returning 2 constant return values
-do
+do  --- test-table-initialization-with-function-returning-two-constants.
   local function f() return 9, 10 end
   local t
   for i=1,100 do t = { 1, 2, 3, f() } end

--- a/test/test.lua
+++ b/test/test.lua
@@ -23,7 +23,8 @@ local function default_tags()
   end
 
   -- Libraries
-  for _, lib in ipairs{"bit", "ffi", "jit.profile", "table.new"} do
+  package.cpath = "./clib/?.so;" .. "clib\\?.dll" .. package.cpath
+  for _, lib in ipairs{"bit", "ffi", "jit.profile", "table.new", "ctest"} do
     if pcall(require, lib) then
       tags[lib] = true
     end

--- a/windows.yml
+++ b/windows.yml
@@ -11,5 +11,6 @@ steps:
     displayName: Windows Build - $(VC_ARCH).
 
   - script: |
+     cd test
      ..\src\luajit.exe test.lua
     displayName: Windows Tests - $(VC_ARCH).

--- a/windows.yml
+++ b/windows.yml
@@ -6,9 +6,10 @@ steps:
      call "%InstallDir%\Common7\Tools\vsdevcmd.bat" -arch=$(VC_ARCH) -startdir=none
      cd src
      call msvcbuild.bat $(buildMode)
+     cd ..\test
+     nmake /F Makefile.win
     displayName: Windows Build - $(VC_ARCH).
 
   - script: |
-     cd test
      ..\src\luajit.exe test.lua
     displayName: Windows Tests - $(VC_ARCH).


### PR DESCRIPTION
Added nmake script for building ctest.dll and cpptest.dll

In `test/test.lua` added `test/clib` to `package.cpath`.
The is done in order to use `ctest` module with `require("ctest")`.

