### PR TITLE
Allow for reproducible output by default

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -117,6 +117,10 @@ XCFLAGS=
 # across CPUs.
 #LUAJIT_ENABLE_REPRODUCIBLE_BUILDS=1
 #
+ifdef SOURCE_DATE_EPOCH
+  LUAJIT_ENABLE_REPRODUCIBLE_BUILDS=1
+endif
+#
 # Enable hardware optimised hashing for string interning.  This uses runtime
 # detection of CPU features and if supported, selects a hash routine best
 # suited for that microarchitecture.  This is disabled for reproducible builds


### PR DESCRIPTION
Allow for reproducible output by default
without every distribution packager reading `Makefile` comments
and enabling the right option.

The variable is documented at
https://reproducible-builds.org/specs/source-date-epoch/
and its existence is a strong indicator for a desire of
reproducible builds.

Related #110
Fixes #123