### PR TITLE
Fix arm64 build

### DIFF
--- a/src/lj_asm_arm64.h
+++ b/src/lj_asm_arm64.h
@@ -868,7 +868,7 @@ static void asm_href(ASMState *as, IRIns *ir, IROp merge)
       emit_lso(as, A64I_LDRx, scr, dest, offsetof(Node, key.u64));
     }
   } else {
-    lua_assert(irt_ispri(kt) && !irt_isnil(kt));
+    lj_assertA(irt_ispri(kt) && !irt_isnil(kt), "bad HREF key type");
     emit_nm(as, A64I_CMPw, scr, type);
     emit_lso(as, A64I_LDRx, scr, dest, offsetof(Node, key));
   }
@@ -1296,7 +1296,6 @@ static void asm_cnew(ASMState *as, IRIns *ir)
     else
       r = ra_alloc1(as, ir->op2, allow);
 
-    lua_assert(sz == 4 || sz == 8);
     lj_assertA(sz == 4 || sz == 8, "bad CNEWI size %d", sz);
     emit_lso(as, sz == 8 ? A64I_STRx : A64I_STRw, r, RID_RET, ofs);
   } else if (ir->op2 != REF_NIL) {  /* Create VLA/VLS/aligned cdata. */


### PR DESCRIPTION
Build error reported. (Ubuntu 20.04 on arm64)

```
$ make
.
. (snip)
.
CC        lj_asm.o
In file included from lj_asm.c:1600:
lj_asm_arm64.h: In function 'asm_href':
lj_asm_arm64.h:871:5: warning: implicit declaration of function 'lua_assert'; did you mean 'lua_insert'? [-Wimplicit-function-declaration]
  871 |     lua_assert(irt_ispri(kt) && !irt_isnil(kt));
      |     ^~~~~~~~~~
      |     lua_insert
In file included from lj_asm.c:1600:
lj_asm_arm64.h: In function 'asm_href':
lj_asm_arm64.h:871:5: warning: implicit declaration of function 'lua_assert'; did you mean 'lua_insert'? [-Wimplicit-function-declaration]
  871 |     lua_assert(irt_ispri(kt) && !irt_isnil(kt));
      |     ^~~~~~~~~~
      |     lua_insert
.
. (snip)
.
LINK      luajit
/usr/bin/ld: libluajit.a(lj_asm.o): in function `asm_href':
lj_asm.c:(.text+0x54a0): undefined reference to `lua_assert'
/usr/bin/ld: libluajit.a(lj_asm.o): in function `lj_asm_trace':
lj_asm.c:(.text+0xac10): undefined reference to `lua_assert'
collect2: error: ld returned 1 exit status
```