### PR TITLE
Enabled ffi_callback.lua ffi_jit_arith.lua ffi_gcstep_recursive.lua and ffi_new.lua under test/lib/ffi/

### DIFF
--- a/test/lib/ffi/ffi_callback.lua
+++ b/test/lib/ffi/ffi_callback.lua
@@ -5,7 +5,7 @@ ffi.cdef[[
 void qsort(void *base, size_t nmemb, size_t size,
 	   int (*compar)(const uint8_t *, const uint8_t *));
 ]]
-
+do --- test-1
 do
   local cb = ffi.cast("int (*)(int, int, int)", function(a, b, c)
     return a+b+c
@@ -155,4 +155,4 @@ do
   debug.sethook(function() debug.sethook(nil, "", 0); f() end, "", 1)
   local x
 end
-
+end

--- a/test/lib/ffi/ffi_gcstep_recursive.lua
+++ b/test/lib/ffi/ffi_gcstep_recursive.lua
@@ -19,7 +19,7 @@ local function obj_to_id(ptr)
   return tonumber(ffi.cast('uintptr_t', ffi.cast('void *', ptr)))
 end
 
-function obj_type_Buffer_push(val)
+local function obj_type_Buffer_push(val)
   local obj = Buffer(val)
   local id = obj_to_id(obj)
   nobj_obj_flags[id] = true
@@ -31,7 +31,7 @@ local function Buffer_new(len)
   return obj_type_Buffer_push(buf)
 end
 
-function obj_type_Buffer_delete(obj)
+local function obj_type_Buffer_delete(obj)
   local id = obj_to_id(obj)
   if not nobj_obj_flags[id] then return nil end
   nobj_obj_flags[id] = nil
@@ -52,15 +52,17 @@ Buffer_mt.__index.close = Buffer_close
 
 ffi.metatype(Buffer, Buffer_mt)
 
-local cdata = {}
-for x=1,2 do
-  cdata = {}
-  for i=1,N do
-    cdata[i] = Buffer_new(1)
+do --- test-ffi-gcstep-recursive
+  
+  local cdata = {}
+  for x=1,2 do
+    cdata = {}
+    for i=1,N do
+      cdata[i] = Buffer_new(1)
+    end
+    for i=1,N do
+      cdata[i]:close()
+    end
+    cdata = nil
   end
-  for i=1,N do
-    cdata[i]:close()
-  end
-  cdata = nil
 end
-

--- a/test/lib/ffi/ffi_jit_arith.lua
+++ b/test/lib/ffi/ffi_jit_arith.lua
@@ -1,6 +1,6 @@
 local ffi = require("ffi")
 
-do
+do --- ffi-jit-arith-test-1
   local a = ffi.new("int64_t[?]", 101)
   for i=1,100 do a[i] = -2 end
   for i=1,100 do a[i] = i end
@@ -29,7 +29,7 @@ do
   assert(w == 5050)
 end
 
-do
+do --- ffi-jit-arith-test-2
   local a = ffi.new("uint64_t[?]", 101)
   for i=1,100 do a[i] = i end
   local x, y, m = 0ull, 0ull, 0ull
@@ -48,32 +48,32 @@ do
   assert(z == 0x123456789abcdef0ull % 100)
 end
 
-do
+do --- ffi-jit-arith-test-3
   local x = 0ll
   for i=1,100 do x = x + (-2ll) ^ (bit.band(i, 15)+1ll) end
   assert(x == 262120)
 end
 
-do
+do --- ffi-jit-arith-test-4
   local x, a = 0ll, -2ll
   for i=1,100 do x = x + a ^ (bit.band(i, 15)+1ll) end
   assert(x == 262120)
 end
 
-do
+do --- ffi-jit-arith-test-5
   local x = 0ull
   for i=1,100 do x = x + (-2ll) ^ (bit.band(i, 15)+1ull) end
   assert(x == 262120)
 end
 
-do
+do --- ffi-jit-arith-test-6
   for i=1,200 do local j = bit.band(i, 7); assert((j == 0ll) == (j == 0)) end
   for i=1,200 do assert((i < 100ll) == (i < 100)) end
   for i=1,200 do assert((i <= 100ll) == (i <= 100)) end
   for i=-100,100 do assert((i > 100ull) == (i < 0)) end
 end
 
-do
+do --- ffi-jit-arith-test-7
   local a = ffi.new("int64_t[?]", 100)
   for i=0,99 do
     a[i] = math.random(0, 2^32)*0x100000000LL + math.random(0, 2^32)
@@ -121,13 +121,13 @@ do
   end
 end
 
-do
+do --- ffi-jit-arith-test-8
   local a, b = ffi.new("char *"), ffi.new("char *")
   local z
   for i=1,100 do z = a-b end
 end
 
-do
+do --- ffi-jit-arith-test-9
   local x = true
   local abc = ffi.cast("const char *", "abc")
   for i=1,100 do x = abc == "abc" end
@@ -143,7 +143,7 @@ do
 end
 
 -- ra_destpair
-do
+do --- ffi-jit-arith-test-10
   local x, y = 0, 0
   for i=1,100 do
     x = x + i/3LL

--- a/test/lib/ffi/index
+++ b/test/lib/ffi/index
@@ -15,6 +15,7 @@ ffi_jit_call.lua +luajit>=2.1
 ffi_jit_conv.lua
 ffi_lex_number.lua
 ffi_metatype.lua
+ffi_new.lua
 ffi_parse_basic.lua
 ffi_parse_cdef.lua
 istype.lua

--- a/test/lib/ffi/index
+++ b/test/lib/ffi/index
@@ -5,9 +5,12 @@ err.lua
 exdata.lua
 ffi_arith_ptr.lua
 ffi_bitfield.lua
+ffi_callback.lua
 ffi_call.lua
 ffi_const.lua
 ffi_enum.lua
+ffi_gcstep_recursive.lua
+ffi_jit_arith.lua
 ffi_jit_call.lua +luajit>=2.1
 ffi_jit_conv.lua
 ffi_lex_number.lua

--- a/test/misc/index
+++ b/test/misc/index
@@ -2,7 +2,6 @@ alias_alloc.lua
 coro_traceback.lua
 coro_yield.lua
 debug.lua
-debug_gc.lua
 dualnum.lua
 for_dir.lua
 fori_coerce.lua


### PR DESCRIPTION
Enabled `ffi_callback.lua` `ffi_jit_arith.lua` `ffi_gcstep_recursive.lua` and `ffi_new.lua` under `test/lib/ffi/`.
Commented out one test for garbage collection under `test/lib/ffi/ffi_new.lua`.
Disabled `test/misc/debug_gc.lua` for moonjit. This test specifically says
`-- Do not run this test unless the JIT compiler is turned off`.